### PR TITLE
Add elk layout (#67)

### DIFF
--- a/custom-ui/package.json
+++ b/custom-ui/package.json
@@ -18,6 +18,7 @@
     "@atlaskit/tokens": "^6.5.0",
     "@forge/bridge": "^5.10.1",
     "@fortawesome/fontawesome-free": "^7.1.0",
+    "@mermaid-js/layout-elk": "^0",
     "mermaid": "^11.12.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/custom-ui/src/__tests__/diagram.test.tsx
+++ b/custom-ui/src/__tests__/diagram.test.tsx
@@ -13,6 +13,7 @@ vi.mock('mermaid', () => ({
   default: {
     initialize: vi.fn(),
     render: vi.fn(),
+    registerLayoutLoaders: vi.fn(),
   },
 }));
 

--- a/custom-ui/src/diagram.tsx
+++ b/custom-ui/src/diagram.tsx
@@ -2,7 +2,10 @@ import { useEffect, useState } from 'react';
 import SVG from 'react-inlinesvg';
 import { TransformWrapper, TransformComponent } from 'react-zoom-pan-pinch';
 import mermaid from 'mermaid';
+import elkLayouts from '@mermaid-js/layout-elk';
 import { Modal, view } from '@forge/bridge';
+
+mermaid.registerLayoutLoaders(elkLayouts);
 import { Box, xcss } from '@atlaskit/primitives';
 import '@fortawesome/fontawesome-free/css/all.css';
 

--- a/custom-ui/src/setup-tests.ts
+++ b/custom-ui/src/setup-tests.ts
@@ -41,7 +41,12 @@ vi.mock('mermaid', () => ({
   default: {
     initialize: vi.fn(),
     render: vi.fn().mockResolvedValue({ svg: '<svg></svg>' }),
+    registerLayoutLoaders: vi.fn(),
   },
+}));
+
+vi.mock('@mermaid-js/layout-elk', () => ({
+  default: {},
 }));
 
 // Mock @forge/bridge

--- a/yarn.lock
+++ b/yarn.lock
@@ -1966,6 +1966,14 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@mermaid-js/layout-elk@^0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@mermaid-js/layout-elk/-/layout-elk-0.2.0.tgz#18df5edf0c08a14ceb9b05d1193b8dabaffa91eb"
+  integrity sha512-vjjYGnCCjYlIA/rR7M//eFi0rHM6dsMyN1JQKfckpt30DTC/esrw36hcrvA2FNPHaqh3Q/SyBWzddyaky8EtUQ==
+  dependencies:
+    d3 "^7.9.0"
+    elkjs "^0.9.3"
+
 "@mermaid-js/parser@^0.6.3":
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/@mermaid-js/parser/-/parser-0.6.3.tgz#3ce92dad2c5d696d29e11e21109c66a7886c824e"
@@ -3620,6 +3628,11 @@ electron-to-chromium@^1.5.249:
   version "1.5.254"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.254.tgz#94b84c0a5faff94b334536090a9dec1c74b10130"
   integrity sha512-DcUsWpVhv9svsKRxnSCZ86SjD+sp32SGidNB37KpqXJncp1mfUgKbHvBomE89WJDbfVKw1mdv5+ikrvd43r+Bg==
+
+elkjs@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/elkjs/-/elkjs-0.9.3.tgz#16711f8ceb09f1b12b99e971b138a8384a529161"
+  integrity sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==
 
 emoji-regex@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
This resolves #67 

Adds the elk layout as a dependency and registers it in the diagram.

I tested this on a development Confluence and verified that this layout syntax works:
```
config:
  layout: elk
```

