### PR TITLE
fix(code-blocks): filter mermaid blocks for auto-detect; fix forge deploy TS incompatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "packageManager": "yarn@1.22.22",
   "resolutions": {
-    "react-hook-form": "7.54.2"
+    "react-hook-form": "7.54.2",
+    "@types/d3-dispatch": "3.0.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2321,10 +2321,10 @@
   resolved "https://registry.yarnpkg.com/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz#185c1a80cc807fdda2a3fe960f7c11c4a27952e1"
   integrity sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==
 
-"@types/d3-dispatch@*":
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz#ef004d8a128046cfce434d17182f834e44ef95b2"
-  integrity sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==
+"@types/d3-dispatch@*", "@types/d3-dispatch@3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/d3-dispatch/-/d3-dispatch-3.0.5.tgz#918f37deaf74485371fa0ab21365ecb415258d89"
+  integrity sha512-hxvq2kc+9hydVppo21JCGfcM0tLTh1DXnG3MLN0KlxsNZJH4bsdl1iXDuWtXFpWWlBrCMwSqlnoLPDxNAZU3Bg==
 
 "@types/d3-drag@*":
   version "3.0.7"


### PR DESCRIPTION
## Context

This PR supersedes #77. It includes all the same changes plus a fix for the `forge deploy` CI failure that was discovered after the review cycle.

## What changed

### Code block detection & filtering
- Adopted `mermaid.getRegisteredDiagramsMetadata()` for diagram type detection instead of a hardcoded list — stays in sync with the library automatically
- `findCodeBlocks` now returns **all** code blocks (not just mermaid ones) — consistent with what the config UI dropdown shows
- `autoMapMacroToCodeBlock` filters to mermaid-only for auto-detection, keeping the right behaviour for the common case
- Kept the `language="mermaid"` fast-path (used by the Atlassian MCP publishing tool)
- `%%` directives and comments before the diagram keyword are correctly skipped during detection
- Semicolons are accepted as diagram keyword delimiters

### Config
- `getIndexFromConfig` now rejects negative indices

### Forge deploy fix
The `forge deploy` CI step was failing with TypeScript errors in `node_modules/@types/d3-dispatch/index.d.ts`:

```
TS1139: Type parameter declaration expected.
```

**Root cause:** `mermaid` depends on `@types/d3`, which transitively pulls in `@types/d3-dispatch`. Version `3.0.6+` of `@types/d3-dispatch` introduced `const` type parameters — a TypeScript 5.0+ feature — which is incompatible with the TypeScript version used by Forge's internal bundler.

**Fix:** Pin `@types/d3-dispatch` to `3.0.5` via Yarn `resolutions` in the root `package.json`. This version has identical runtime types without the TS 5.0+ syntax.

## Test plan
- [ ] All 45 unit tests pass with 100% coverage (`shared` package)
- [ ] Lint passes with 0 warnings
- [ ] `forge deploy` CI step passes (no more `@types/d3-dispatch` TS errors)