### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/atlassian-labs/mermaid-diagrams-viewer/security/code-scanning/13](https://github.com/atlassian-labs/mermaid-diagrams-viewer/security/code-scanning/13)

In general, fix this by adding an explicit `permissions:` block that grants only the minimal `GITHUB_TOKEN` scopes required by the workflow, either at the top level (applies to all jobs) or individually per job. Since all jobs here only need to read repository contents and use artifacts, `contents: read` is an appropriate minimal configuration.

The single best fix without changing existing functionality is to add a workflow-level `permissions:` block just under the `name: CI` line. This way every job (`test`, `build-forge-app`, `build-custom-ui`, `deploy-development`, `deploy-staging`, and the omitted `deploy-production`) inherits the same restricted token permissions, and we do not need to repeat configuration. No steps in the shown jobs perform GitHub write operations (no pushing commits, creating releases, or modifying issues/PRs), so `contents: read` is sufficient and should not break anything. No imports or additional definitions are needed; this is a pure YAML configuration change in `.github/workflows/ci.yml`.

Specifically, modify `.github/workflows/ci.yml` by inserting:

```yaml
permissions:
  contents: read
```

between line 1 (`name: CI`) and line 3 (`on:`), keeping indentation consistent with the top-level keys.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
