### PR TITLE
fix(custom-ui): only reserve min-height while the diagram is loading

### DIFF
--- a/custom-ui/src/__tests__/app.test.tsx
+++ b/custom-ui/src/__tests__/app.test.tsx
@@ -203,4 +203,41 @@ describe('App Component', () => {
       );
     });
   });
+
+  it('reserves a 150px min-height while loading', async () => {
+    let resolveCode: (value: string) => void = () => {};
+    mockGetCodeFromCorrespondingBlock.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveCode = resolve;
+      }),
+    );
+
+    let renderResult!: ReturnType<typeof render>;
+    act(() => {
+      renderResult = render(<App colorMode="light" />);
+    });
+
+    const container = renderResult.container.firstChild as HTMLElement;
+    expect(container.style.minHeight).toBe('150px');
+
+    // Settle the pending load so the effect resolves without act() warnings.
+    await act(async () => {
+      resolveCode('graph TD\n  A --> B');
+      await Promise.resolve();
+    });
+  });
+
+  it('drops the min-height once the diagram has rendered', async () => {
+    let renderResult!: ReturnType<typeof render>;
+    act(() => {
+      renderResult = render(<App colorMode="light" />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('diagram')).toBeDefined();
+    });
+
+    const container = renderResult.container.firstChild as HTMLElement;
+    expect(container.style.minHeight).toBe('');
+  });
 });

--- a/custom-ui/src/app.tsx
+++ b/custom-ui/src/app.tsx
@@ -89,15 +89,21 @@ function App({ colorMode }: { colorMode: 'light' | 'dark' }) {
     setError(error);
   };
 
+  const isLoading = code === undefined && error === undefined;
+
   return (
     <div
       style={{
-        minHeight: '150px',
+        // Reserve vertical space for the loading spinner only while loading.
+        // Once the diagram has rendered, let the container hug its content so a
+        // short diagram (e.g. a small left-to-right flowchart) does not leave
+        // empty vertical space below it.
+        minHeight: isLoading ? '150px' : undefined,
         backgroundColor: token('elevation.surface'),
         borderRadius: '3px',
       }}
     >
-      {code === undefined && error === undefined ? <Loading /> : null}
+      {isLoading ? <Loading /> : null}
       {code !== undefined ? (
         <Diagram code={code} colorMode={colorMode} onError={onError} />
       ) : null}


### PR DESCRIPTION
## Problem

The macro view container in `custom-ui/src/app.tsx` hard-codes `minHeight: '150px'`. That floor is there to give the loading spinner room, but it stays applied after the diagram has rendered. As a result, a diagram whose natural height is below 150px (for example a small left-to-right `flowchart LR`) renders at the top of the macro box and leaves empty vertical space beneath it.

## Change

Apply the 150px floor only while loading. Once the diagram has rendered (or an error is shown), the container hugs its content. Loading and error states are unchanged.

```diff
-        minHeight: '150px',
+        minHeight: isLoading ? '150px' : undefined,
```

## Tests

Added two tests in `custom-ui/src/__tests__/app.test.tsx`:

- the container reserves a 150px min-height while loading
- the container drops the min-height once the diagram has rendered

## Verification (local)

- `yarn lint` — clean (`--max-warnings 0`)
- `yarn test` — 68 passed
- `yarn build` — success
