### PR TITLE
fix: preserve Mermaid SVG presentation styles

### DIFF
--- a/custom-ui/src/__tests__/diagram.test.tsx
+++ b/custom-ui/src/__tests__/diagram.test.tsx
@@ -6,7 +6,7 @@ import {
   waitFor,
 } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { Diagram } from '../diagram';
+import { Diagram, preserveSvgPresentationStyles } from '../diagram';
 
 // Mock mermaid
 vi.mock('mermaid', () => ({
@@ -107,6 +107,59 @@ describe('Diagram Component', () => {
 
     // Since modalIsOpen is false by default, we should see the Box layout, not transform components
     expect(svgComponent).toBeInTheDocument();
+  });
+
+  it('should preserve inline SVG presentation styles as attributes', async () => {
+    mockMermaid.render.mockResolvedValue({
+      svg: `<svg xmlns="http://www.w3.org/2000/svg">
+        <g class="node custom">
+          <path style="fill: #be123c !important; stroke: #fb7185 !important; stroke-width: 2px; cursor: pointer" />
+        </g>
+      </svg>`,
+      diagramType: 'flowchart',
+      bindFunctions: vi.fn(),
+    });
+
+    render(<Diagram {...defaultProps} />);
+
+    const svgComponent = await screen.findByTestId('svg-component');
+    await waitFor(() => {
+      expect(svgComponent.getAttribute('data-src')).toContain('<path');
+    });
+    const renderedSvg = svgComponent.getAttribute('data-src');
+    const document = new DOMParser().parseFromString(
+      renderedSvg ?? '',
+      'image/svg+xml',
+    );
+    const path = document.querySelector('path');
+
+    expect(path?.getAttribute('fill')).toBe('rgb(190, 18, 60)');
+    expect(path?.getAttribute('stroke')).toBe('rgb(251, 113, 133)');
+    expect(path?.getAttribute('stroke-width')).toBe('2px');
+    expect(path?.hasAttribute('cursor')).toBe(false);
+  });
+
+  it('should leave HTML styles inside foreignObject unchanged', () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg">
+      <foreignObject>
+        <div xmlns="http://www.w3.org/1999/xhtml" style="color: red" />
+      </foreignObject>
+    </svg>`;
+
+    const document = new DOMParser().parseFromString(
+      preserveSvgPresentationStyles(svg),
+      'image/svg+xml',
+    );
+    const div = document.querySelector('div');
+
+    expect(div?.hasAttribute('color')).toBe(false);
+    expect(div?.getAttribute('style')).toBe('color: red');
+  });
+
+  it('should return invalid SVG unchanged', () => {
+    const svg = '<svg><path></svg>';
+
+    expect(preserveSvgPresentationStyles(svg)).toBe(svg);
   });
 
   it('should render transform components when modal is open', async () => {

--- a/custom-ui/src/__tests__/diagram.test.tsx
+++ b/custom-ui/src/__tests__/diagram.test.tsx
@@ -137,6 +137,10 @@ describe('Diagram Component', () => {
     expect(path?.getAttribute('stroke')).toBe('rgb(251, 113, 133)');
     expect(path?.getAttribute('stroke-width')).toBe('2px');
     expect(path?.hasAttribute('cursor')).toBe(false);
+    expect(path?.classList).toContain('mermaid-preserved-style-0');
+    expect(document.querySelector('style')?.textContent).toBe(
+      '.mermaid-preserved-style-0 { fill: rgb(190, 18, 60) !important; stroke: rgb(251, 113, 133) !important; stroke-width: 2px !important; }',
+    );
   });
 
   it('should leave HTML styles inside foreignObject unchanged', () => {

--- a/custom-ui/src/diagram.tsx
+++ b/custom-ui/src/diagram.tsx
@@ -25,6 +25,7 @@ const boxStyle: React.CSSProperties = {
 };
 
 const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+const PRESERVED_STYLE_CLASS_PREFIX = 'mermaid-preserved-style-';
 const SVG_PRESENTATION_ATTRIBUTES = new Set([
   'color',
   'display',
@@ -63,19 +64,34 @@ export function preserveSvgPresentationStyles(svg: string): string {
     return svg;
   }
 
+  const preservedStyleRules: string[] = [];
+
   for (const element of document.querySelectorAll<SVGElement>('[style]')) {
     if (element.namespaceURI !== SVG_NAMESPACE) {
       continue;
     }
 
+    const declarations: string[] = [];
     for (const property of element.style) {
       if (SVG_PRESENTATION_ATTRIBUTES.has(property)) {
-        element.setAttribute(
-          property,
-          element.style.getPropertyValue(property),
-        );
+        const value = element.style.getPropertyValue(property);
+        element.setAttribute(property, value);
+        declarations.push(`${property}: ${value} !important;`);
       }
     }
+
+    if (declarations.length > 0) {
+      const className =
+        PRESERVED_STYLE_CLASS_PREFIX + String(preservedStyleRules.length);
+      element.classList.add(className);
+      preservedStyleRules.push(`.${className} { ${declarations.join(' ')} }`);
+    }
+  }
+
+  if (preservedStyleRules.length > 0) {
+    const style = document.createElementNS(SVG_NAMESPACE, 'style');
+    style.textContent = preservedStyleRules.join('\n');
+    document.documentElement.append(style);
   }
 
   return new XMLSerializer().serializeToString(document.documentElement);

--- a/custom-ui/src/diagram.tsx
+++ b/custom-ui/src/diagram.tsx
@@ -24,6 +24,63 @@ const boxStyle: React.CSSProperties = {
   backgroundColor: 'var(--ds-background-neutral-subtle, transparent)',
 };
 
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+const SVG_PRESENTATION_ATTRIBUTES = new Set([
+  'color',
+  'display',
+  'dominant-baseline',
+  'fill',
+  'fill-opacity',
+  'fill-rule',
+  'font-family',
+  'font-size',
+  'font-style',
+  'font-weight',
+  'marker-end',
+  'marker-mid',
+  'marker-start',
+  'opacity',
+  'paint-order',
+  'shape-rendering',
+  'stroke',
+  'stroke-dasharray',
+  'stroke-dashoffset',
+  'stroke-linecap',
+  'stroke-linejoin',
+  'stroke-miterlimit',
+  'stroke-opacity',
+  'stroke-width',
+  'text-anchor',
+  'transform',
+  'vector-effect',
+  'visibility',
+]);
+
+export function preserveSvgPresentationStyles(svg: string): string {
+  const document = new DOMParser().parseFromString(svg, 'image/svg+xml');
+
+  if (document.querySelector('parsererror')) {
+    return svg;
+  }
+
+  for (const element of document.querySelectorAll<SVGElement>('[style]')) {
+    if (element.namespaceURI !== SVG_NAMESPACE) {
+      continue;
+    }
+
+    for (const property of element.style) {
+      if (SVG_PRESENTATION_ATTRIBUTES.has(property)) {
+        element.setAttribute(
+          property,
+          element.style.getPropertyValue(property),
+        );
+      }
+    }
+  }
+
+  return new XMLSerializer().serializeToString(document.documentElement);
+}
+
 export const Diagram: React.FunctionComponent<{
   code: string;
   colorMode: 'light' | 'dark';
@@ -121,7 +178,7 @@ function useMermaidRenderSVG(code: string, colorMode: 'light' | 'dark') {
           'diagram' + String(Date.now()),
           code,
         );
-        setSvg(svg);
+        setSvg(preserveSvgPresentationStyles(svg));
       } catch (error) {
         setError(error as Error);
       }


### PR DESCRIPTION
## Summary

- copy Mermaid inline SVG presentation styles to equivalent presentation attributes before rendering
- preserve the original inline styles while ignoring non-SVG elements and unrelated CSS properties
- add regression coverage for styled roughjs paths, foreign objects, and invalid SVG fallback

Fixes #128.

Credit to @senstar-nross for isolating the Forge sanitization and roughjs wrapper interaction.

## Testing

- `yarn test --coverage` (69 tests passed)
- `yarn lint`
- `yarn build`

## Not run

- Forge/Confluence end-to-end verification, which requires a deployed installation; the SVG transformation is covered by deterministic regression tests.