### PR TITLE
feat: add manual diagram refresh

### DIFF
--- a/custom-ui/src/__tests__/app.test.tsx
+++ b/custom-ui/src/__tests__/app.test.tsx
@@ -1,4 +1,10 @@
-import { render, screen, waitFor, act } from '@testing-library/react';
+import {
+  render,
+  screen,
+  waitFor,
+  act,
+  fireEvent,
+} from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { Context } from '../context';
 
@@ -61,6 +67,7 @@ import App from '../app';
 import { Diagram } from '../diagram';
 import { view } from '@forge/bridge';
 import { getCodeFromCorrespondingBlock } from '../confluence/code-blocks';
+import { getPageContent } from '../confluence/api-client/browser';
 import { AppError } from '../app-error';
 
 // Get mocked functions using vi.mocked
@@ -69,6 +76,7 @@ const mockView = vi.mocked(view);
 const mockGetCodeFromCorrespondingBlock = vi.mocked(
   getCodeFromCorrespondingBlock,
 );
+const mockGetPageContent = vi.mocked(getPageContent);
 
 describe('App Component', () => {
   beforeEach(() => {
@@ -196,6 +204,47 @@ describe('App Component', () => {
       expect(mockDiagram).toHaveBeenCalledWith(
         {
           code: 'graph TD\n  A --> B',
+          colorMode: 'light',
+          onError: expect.any(Function) as (error: Error) => void,
+        },
+        undefined,
+      );
+    });
+  });
+
+  it('refreshes the diagram from an uncached page request', async () => {
+    mockGetCodeFromCorrespondingBlock.mockImplementation(
+      async (_context, loadPageContent) => {
+        if (mockGetCodeFromCorrespondingBlock.mock.calls.length === 1) {
+          return 'graph TD\n  A --> B';
+        }
+        await loadPageContent('test-content-id', false);
+        return 'graph LR\n  C --> D';
+      },
+    );
+
+    render(<App colorMode="light" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('diagram')).toBeDefined();
+    });
+    const callsBeforeRefresh =
+      mockGetCodeFromCorrespondingBlock.mock.calls.length;
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh diagram' }));
+
+    await waitFor(() => {
+      expect(mockGetCodeFromCorrespondingBlock).toHaveBeenCalledTimes(
+        callsBeforeRefresh + 1,
+      );
+      expect(mockGetPageContent).toHaveBeenCalledWith(
+        'test-content-id',
+        false,
+        expect.any(String),
+      );
+      expect(mockDiagram).toHaveBeenLastCalledWith(
+        {
+          code: 'graph LR\n  C --> D',
           colorMode: 'light',
           onError: expect.any(Function) as (error: Error) => void,
         },

--- a/custom-ui/src/__tests__/browser.test.ts
+++ b/custom-ui/src/__tests__/browser.test.ts
@@ -88,6 +88,29 @@ describe('api-client/browser', () => {
       );
     });
 
+    it('should add a cache-busting value when refreshing page content', async () => {
+      const mockResponse: MockResponse = {
+        status: 200,
+        json: vi.fn().mockResolvedValue(mockPageResponse),
+      };
+      mockRequestConfluence.mockResolvedValue(
+        mockResponse as unknown as Awaited<
+          ReturnType<typeof requestConfluence>
+        >,
+      );
+
+      await getPageContent(pageId, false, 'refresh-123');
+
+      expect(mockRequestConfluence).toHaveBeenCalledWith(
+        `/wiki/api/v2/pages/${pageId}?body-format=atlas_doc_format&get-draft=false&cache-bust=refresh-123`,
+        {
+          headers: {
+            Accept: 'application/json',
+          },
+        },
+      );
+    });
+
     it('should fallback to blogpost API when page returns 404', async () => {
       const mockNotFoundResponse: MockResponse = {
         status: 404,

--- a/custom-ui/src/app.tsx
+++ b/custom-ui/src/app.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import Banner from '@atlaskit/banner';
+import Button from '@atlaskit/button/new';
 import Spinner from '@atlaskit/spinner';
 import { Diagram } from './diagram';
 import { token } from '@atlaskit/tokens';
@@ -53,37 +54,77 @@ const Loading: React.FunctionComponent<{ loading?: boolean }> = () => {
   );
 };
 
+const RefreshIcon = () => (
+  <span
+    aria-hidden="true"
+    className="fa-solid fa-rotate-right"
+    style={{
+      display: 'inline-block',
+      fontSize: '12px',
+      height: '12px',
+      width: '12px',
+    }}
+  />
+);
+
+function toDisplayError(error: unknown): AppError | Error {
+  if (error instanceof AppError) {
+    return error;
+  }
+
+  // eslint-disable-next-line no-console
+  console.error(error);
+
+  return new AppError(
+    'Oops! Something went wrong! Please refresh the page.',
+    'UNKNOWN_ERROR',
+  );
+}
+
 function App({ colorMode }: { colorMode: 'light' | 'dark' }) {
   const [code, setCode] = useState<string>();
   const [error, setError] = useState<AppError | Error | undefined>();
+  const [loading, setLoading] = useState(true);
+  const [renderVersion, setRenderVersion] = useState(0);
 
-  useEffect(() => {
-    void view
+  const fetchDiagramCode = useCallback((cacheBust?: string) => {
+    return view
       .getContext()
       .then((context) =>
         getCodeFromCorrespondingBlock(
           context as unknown as Context,
-          getPageContent,
+          (pageId, isEditing) => getPageContent(pageId, isEditing, cacheBust),
         ),
-      ) // TODO
+      );
+  }, []);
+
+  useEffect(() => {
+    void fetchDiagramCode()
       .then(setCode)
       .catch((error: unknown) => {
-        if (error instanceof AppError) {
-          setError(error);
-          return;
-        }
-
-        // eslint-disable-next-line no-console
-        console.error(error);
-
-        setError(
-          new AppError(
-            'Oops! Something went wrong! Please refresh the page.',
-            'UNKNOWN_ERROR',
-          ),
-        );
+        setError(toDisplayError(error));
+      })
+      .finally(() => {
+        setLoading(false);
       });
-  }, []);
+  }, [fetchDiagramCode]);
+
+  const refreshDiagram = () => {
+    setLoading(true);
+    setError(undefined);
+
+    void fetchDiagramCode(String(Date.now()))
+      .then((nextCode) => {
+        setCode(nextCode);
+        setRenderVersion((version) => version + 1);
+      })
+      .catch((error: unknown) => {
+        setError(toDisplayError(error));
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  };
 
   const onError = (error: Error) => {
     setError(error);
@@ -99,7 +140,32 @@ function App({ colorMode }: { colorMode: 'light' | 'dark' }) {
     >
       {code === undefined && error === undefined ? <Loading /> : null}
       {code !== undefined ? (
-        <Diagram code={code} colorMode={colorMode} onError={onError} />
+        <>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              paddingBottom: token('space.100', '8px'),
+            }}
+          >
+            <Button
+              aria-label="Refresh diagram"
+              appearance="subtle"
+              iconBefore={RefreshIcon}
+              isLoading={loading}
+              onClick={refreshDiagram}
+              spacing="compact"
+            >
+              Refresh
+            </Button>
+          </div>
+          <Diagram
+            key={renderVersion}
+            code={code}
+            colorMode={colorMode}
+            onError={onError}
+          />
+        </>
       ) : null}
       <ErrorMessage error={error} />
     </div>

--- a/custom-ui/src/confluence/api-client/browser.ts
+++ b/custom-ui/src/confluence/api-client/browser.ts
@@ -1,9 +1,16 @@
 import { requestConfluence } from '@forge/bridge';
 import { ADFEntity, GetPageContent, PageResponseBody } from './types';
 
-export const getPageContent: GetPageContent = async (pageId, isEditing) => {
+export const getPageContent: GetPageContent = async (
+  pageId,
+  isEditing,
+  cacheBust,
+) => {
+  const cacheBustQuery = cacheBust
+    ? `&cache-bust=${encodeURIComponent(cacheBust)}`
+    : '';
   let pageResponse = await requestConfluence(
-    `/wiki/api/v2/pages/${pageId}?body-format=atlas_doc_format&get-draft=${isEditing.toString()}`,
+    `/wiki/api/v2/pages/${pageId}?body-format=atlas_doc_format&get-draft=${isEditing.toString()}${cacheBustQuery}`,
     {
       headers: {
         Accept: 'application/json',
@@ -13,7 +20,7 @@ export const getPageContent: GetPageContent = async (pageId, isEditing) => {
 
   if (pageResponse.status === 404) {
     pageResponse = await requestConfluence(
-      `/wiki/api/v2/blogposts/${pageId}?body-format=atlas_doc_format&get-draft=${isEditing.toString()}`,
+      `/wiki/api/v2/blogposts/${pageId}?body-format=atlas_doc_format&get-draft=${isEditing.toString()}${cacheBustQuery}`,
       {
         headers: {
           Accept: 'application/json',

--- a/custom-ui/src/confluence/api-client/types.ts
+++ b/custom-ui/src/confluence/api-client/types.ts
@@ -9,4 +9,5 @@ export type { ADFEntity } from '@atlaskit/adf-utils/types';
 export type GetPageContent = (
   pageId: string,
   isEditing: boolean,
+  cacheBust?: string,
 ) => Promise<ADFEntity>;


### PR DESCRIPTION
Fixes #52

Good catch, @kopach. A manual refresh avoids having to switch diagrams or recreate the macro after editing its source code.

## Problem

The viewer loads its corresponding code block only when the component mounts. It has no way to fetch the source again or force Mermaid to regenerate the diagram, and repeated Confluence API URLs may return a cached response.

## Implementation

- Add a compact, accessible Refresh control above a loaded diagram.
- Fetch the current code block again with a per-refresh cache-busting query value.
- Keep the last successful diagram visible while refreshing and surface refresh failures through the existing error banner.
- Remount the Mermaid renderer after a successful refresh, including when the returned source text is unchanged.
- Cover the refresh interaction and cache-busted API URL with regression tests.

## Compatibility

Initial page and blog-post requests are unchanged. The new API-client argument is optional, the existing blog-post fallback remains intact, and no stored configuration format changes.

## Validation

- `vitest run`: 68 tests passed
- `eslint . --report-unused-disable-directives --max-warnings 0`
- `tsc && vite build`
- Browser interaction checks at 1280x720 and 390x720 confirmed refreshed source, a cache-busted request, visible loading control, and no horizontal overflow

## Not run

- A deployed Confluence/Forge installation was not available for an end-to-end check.
