### PR TITLE
Require real Confluence validation for contributions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,17 @@
+# Mermaid Diagrams Viewer review instructions
+
+[CONTRIBUTING.md](../CONTRIBUTING.md) is the canonical source for contribution,
+testing, and evidence requirements. Apply it when generating or reviewing code.
+
+- Treat missing real-Confluence testing and evidence as blocking for any change
+  that can affect the shipped app.
+- Unit tests use mocked Mermaid and Forge boundaries. Do not describe them as
+  end-to-end coverage or assume green CI proves Confluence behavior.
+- Check that pull request evidence names the current head commit and comes from
+  real Confluence rather than a standalone or mocked preview.
+- Flag accidental changes to the upstream `app.id` in `app/manifest.yml`.
+- Review for maintainability, regression risk, permission and scope changes,
+  product integration behavior, and adequate tests. A generated implementation
+  is not complete until the contributor has validated and understood it.
+- Never recommend merging a pull request whose required checks, Confluence
+  evidence, or review conversations remain incomplete.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,8 +3,12 @@
 [CONTRIBUTING.md](../CONTRIBUTING.md) is the canonical source for contribution,
 testing, and evidence requirements. Apply it when generating or reviewing code.
 
-- Treat missing real-Confluence testing and evidence as blocking for any change
-  that can affect the shipped app.
+- Treat missing real-Confluence testing and evidence as blocking when a change
+  that can affect the shipped app is marked ready for review or considered for
+  merge.
+- Do not review draft pull requests unless a draft links an issue that asks a
+  specific technical or UX question. In that case, limit feedback to that
+  question rather than reviewing the implementation generally.
 - Unit tests use mocked Mermaid and Forge boundaries. Do not describe them as
   end-to-end coverage or assume green CI proves Confluence behavior.
 - Check that pull request evidence names the current head commit and comes from

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,71 +1,33 @@
 <!--
-Do not submit this pull request until the final commit satisfies CONTRIBUTING.md.
-Remove placeholders, choose exactly one E2E option, and complete the applicable
-checklists. Use an issue or discussion if you need setup help before submission.
+For changes that affect the app, test the final source in real Confluence before
+opening the PR. GitHub already reports automated checks, so do not copy them
+into the description. See CONTRIBUTING.md for the full requirements.
 -->
 
 ## Summary
 
-<!-- What changed, why it is needed, and any issue it resolves. -->
+<!-- What changed and why? Link the issue when there is one. -->
 
-## Real Confluence validation
+## Confluence test
 
-Choose exactly one:
-
-- [ ] **Required:** I tested the source at the final commit in a real Confluence
-      Cloud site, with only the documented local `app.id` substitution.
-- [ ] **Exemption requested:** Confluence testing cannot provide meaningful
-      evidence for this change. I explained why below.
+Tested in Confluence: `YES_OR_NOT_APPLICABLE`
 
 Tested commit: `FULL_40_CHARACTER_COMMIT_SHA_OR_N/A`
 
-Forge environment: `development_OR_N/A`
-
 Browser: `BROWSER_AND_VERSION_OR_N/A`
 
-When real-Confluence validation is required:
+What I tested:
 
-- [ ] The tested commit above is the current pull request head, and there were
-      no other uncommitted source changes during testing.
-- [ ] The evidence below includes at least one screenshot from a real
-      Confluence page, with before/after evidence or a recording where needed.
+<!-- Briefly describe what you did in Confluence and what happened. -->
 
-### Scenarios and results
-
-| Scenario | Expected | Actual |
-| --- | --- | --- |
-| Replace with the behavior tested | Replace with the expected result | Replace with the observed result |
-
-### Evidence
+Evidence:
 
 <!--
-Attach screenshots from a real Confluence page. Include before/after images for
-visual changes and a recording or animated image for interactions when needed.
-Show enough Confluence context to distinguish it from a standalone preview, and
-remove private information. Do not include customer data, tokens, or secrets.
+Attach at least one screenshot from real Confluence. Use before/after images for
+visual fixes and a recording when screenshots cannot show the interaction.
+Remove private information and never include customer data or secrets.
 -->
 
-### Exemption reason
+Why this is not applicable:
 
-<!-- Required only when "Exemption requested" is selected. -->
-
-## Automated checks
-
-- [ ] `yarn lint`
-- [ ] `yarn test --coverage`
-- [ ] `yarn build`
-- [ ] `forge lint` when the Forge app or manifest is affected
-- [ ] I added or updated automated tests for changed behavior
-
-Explanation for any unchecked check: `N/A_OR_EXPLANATION`
-
-## Contributor declaration
-
-- [ ] I reviewed and understand the entire diff, including AI-generated or
-      AI-modified code.
-- [ ] The validation claims, evidence, and exemption request above are accurate;
-      no result or evidence was fabricated or copied from unrelated behavior.
-- [ ] After the latest change, I retested and updated the evidence or confirmed
-      that the requested exemption still applies.
-- [ ] This pull request does not contain my contributor-owned Forge `app.id`,
-      customer data, credentials, or other secrets.
+<!-- Complete this only for documentation or another exempt change. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,20 +1,27 @@
 <!--
 For changes that affect the app, test the final source in real Confluence before
-opening the PR. GitHub already reports automated checks, so do not copy them
-into the description. See CONTRIBUTING.md for the full requirements.
+marking the PR ready for review. A draft may be opened earlier to align on a
+high-level approach, but it will not be reviewed unless it links an issue with
+a specific technical or UX question; review will be limited to that question.
+GitHub already reports automated checks, so do not copy them into the
+description. See CONTRIBUTING.md for the full requirements.
 -->
 
 ## Summary
 
-<!-- What changed and why? Link the issue when there is one. -->
+<!-- What changed and why? For an alignment draft, link the issue containing the
+specific technical or UX question. -->
 
 ## Confluence test
 
-Tested in Confluence: `YES_OR_NOT_APPLICABLE`
+<!-- An alignment draft may use PENDING_WHILE_DRAFT. Complete this section
+before marking an app-affecting pull request ready for review. -->
 
-Tested commit: `FULL_40_CHARACTER_COMMIT_SHA_OR_N/A`
+Test status: `TESTED_OR_NOT_APPLICABLE_OR_PENDING_WHILE_DRAFT`
 
-Browser: `BROWSER_AND_VERSION_OR_N/A`
+Tested commit: `FULL_40_CHARACTER_COMMIT_SHA_OR_N/A_OR_PENDING`
+
+Browser: `BROWSER_AND_VERSION_OR_N/A_OR_PENDING`
 
 What I tested:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,71 @@
+<!--
+Do not submit this pull request until the final commit satisfies CONTRIBUTING.md.
+Remove placeholders, choose exactly one E2E option, and complete the applicable
+checklists. Use an issue or discussion if you need setup help before submission.
+-->
+
+## Summary
+
+<!-- What changed, why it is needed, and any issue it resolves. -->
+
+## Real Confluence validation
+
+Choose exactly one:
+
+- [ ] **Required:** I tested the source at the final commit in a real Confluence
+      Cloud site, with only the documented local `app.id` substitution.
+- [ ] **Exemption requested:** Confluence testing cannot provide meaningful
+      evidence for this change. I explained why below.
+
+Tested commit: `FULL_40_CHARACTER_COMMIT_SHA_OR_N/A`
+
+Forge environment: `development_OR_N/A`
+
+Browser: `BROWSER_AND_VERSION_OR_N/A`
+
+When real-Confluence validation is required:
+
+- [ ] The tested commit above is the current pull request head, and there were
+      no other uncommitted source changes during testing.
+- [ ] The evidence below includes at least one screenshot from a real
+      Confluence page, with before/after evidence or a recording where needed.
+
+### Scenarios and results
+
+| Scenario | Expected | Actual |
+| --- | --- | --- |
+| Replace with the behavior tested | Replace with the expected result | Replace with the observed result |
+
+### Evidence
+
+<!--
+Attach screenshots from a real Confluence page. Include before/after images for
+visual changes and a recording or animated image for interactions when needed.
+Show enough Confluence context to distinguish it from a standalone preview, and
+remove private information. Do not include customer data, tokens, or secrets.
+-->
+
+### Exemption reason
+
+<!-- Required only when "Exemption requested" is selected. -->
+
+## Automated checks
+
+- [ ] `yarn lint`
+- [ ] `yarn test --coverage`
+- [ ] `yarn build`
+- [ ] `forge lint` when the Forge app or manifest is affected
+- [ ] I added or updated automated tests for changed behavior
+
+Explanation for any unchecked check: `N/A_OR_EXPLANATION`
+
+## Contributor declaration
+
+- [ ] I reviewed and understand the entire diff, including AI-generated or
+      AI-modified code.
+- [ ] The validation claims, evidence, and exemption request above are accurate;
+      no result or evidence was fabricated or copied from unrelated behavior.
+- [ ] After the latest change, I retested and updated the evidence or confirmed
+      that the requested exemption still applies.
+- [ ] This pull request does not contain my contributor-owned Forge `app.id`,
+      customer data, credentials, or other secrets.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Repository instructions for AI agents
+
+Follow [CONTRIBUTING.md](CONTRIBUTING.md) for every change. It is the canonical
+source for contribution, testing, and evidence requirements. Read
+[Testing a fork in Confluence](docs/testing-in-confluence.md) before changing
+application or Forge behavior.
+
+## Pull request hard stop
+
+- Do not open a pull request, including a draft, for a change that can affect
+  the shipped app until the source at the final commit has been tested in a real
+  Confluence Cloud site, with no working-tree difference except the documented
+  contributor-owned `app.id` substitution.
+- Do not treat unit tests, mocked Forge APIs, a standalone browser preview, or a
+  successful build as Confluence end-to-end testing.
+- Do not claim that a test ran, invent results, or fabricate screenshots.
+- If you cannot access Forge or a suitable Confluence site, stop before opening
+  a pull request and report the blocker. Use an issue or discussion when early
+  maintainer input is needed.
+- Use only the exemptions defined in `CONTRIBUTING.md`. State the reason in the
+  pull request, and do not invent or self-approve an ambiguous exemption.
+
+## Repository-specific safeguards
+
+- Test a fork under a contributor-owned Forge app created with
+  `forge register`; never deploy against the upstream app registration.
+- Never commit the contributor-owned `app.id` written to `app/manifest.yml` by
+  `forge register`.
+- Bind manual evidence to the full commit SHA whose source was tested and retest
+  after any change to that commit.
+- Review and understand all generated changes. The agent and contributor own
+  their correctness and maintainability regardless of which tool produced them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,18 +5,25 @@ source for contribution, testing, and evidence requirements. Read
 [Testing a fork in Confluence](docs/testing-in-confluence.md) before changing
 application or Forge behavior.
 
-## Pull request hard stop
+## Pull request readiness gate
 
-- Do not open a pull request, including a draft, for a change that can affect
-  the shipped app until the source at the final commit has been tested in a real
+- Do not mark a pull request ready for review for a change that can affect the
+  shipped app until the source at the final commit has been tested in a real
   Confluence Cloud site, with no working-tree difference except the documented
   contributor-owned `app.id` substitution.
+- A draft pull request may be opened earlier to align on a high-level approach,
+  but maintainers do not review drafts except for the focused decision described
+  below. Do not request general implementation review while the pull request is
+  a draft.
+- If work cannot reasonably continue without a specific technical or UX
+  decision, open an issue that states the decision and exact question, then
+  link it from the draft. Request feedback only on that question.
 - Do not treat unit tests, mocked Forge APIs, a standalone browser preview, or a
   successful build as Confluence end-to-end testing.
 - Do not claim that a test ran, invent results, or fabricate screenshots.
-- If you cannot access Forge or a suitable Confluence site, stop before opening
-  a pull request and report the blocker. Use an issue or discussion when early
-  maintainer input is needed.
+- If you cannot access Forge or a suitable Confluence site, do not mark the pull
+  request ready for review. Report the blocker in an issue or discussion; lack
+  of access does not exempt the change from Confluence testing.
 - Use only the exemptions defined in `CONTRIBUTING.md`. State the reason in the
   pull request, and do not invent or self-approve an ambiguous exemption.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ This is a Forge app that runs inside Confluence Cloud. Unit tests and a local
 browser preview cannot reproduce all of the product APIs, iframe behavior,
 sanitization, themes, editor states, and permissions that the released app
 depends on. Changes that can affect the shipped app must therefore be tested in
-a real Confluence Cloud site before a pull request is opened.
+a real Confluence Cloud site before a pull request is marked ready for review.
 
 ## Before you start
 
@@ -22,7 +22,7 @@ a real Confluence Cloud site before a pull request is opened.
 
 ## Definition of done
 
-Before opening a pull request, you must:
+Before marking a pull request ready for review, you must:
 
 1. Understand the change and review the entire diff, including any
    AI-generated or AI-modified code.
@@ -35,9 +35,18 @@ Before opening a pull request, you must:
 5. Add the Confluence evidence, or explain why the documented exemption applies,
    in the pull request.
 
-Do not open a draft pull request to bypass these requirements. If a maintainer
-has explicitly requested an early draft for collaboration, explain that in the
-pull request.
+### Draft pull requests
+
+A draft pull request may be opened before implementation and Confluence testing
+are complete when it helps align on the high-level approach. Maintainers do not
+review draft pull requests except for the focused decision described below.
+
+If work cannot reasonably continue without a specific technical or UX decision,
+open an issue first. State the decision and the exact question in the issue,
+then link it from the draft pull request. Maintainer feedback on the draft will
+be limited to that question. General implementation review begins only after
+the pull request satisfies the definition of done and is marked ready for
+review.
 
 ### When real-Confluence testing is required
 
@@ -106,10 +115,11 @@ provide evidence that was not produced by the submitted change.
 
 ## Incomplete pull requests
 
-A pull request that is missing required Confluence evidence is not ready for
-maintainer review. Maintainers may label it as needing evidence and close it
-after seven days without a qualifying contributor update. A closed pull request
-can be reopened when the required testing and evidence are ready.
+A non-draft pull request that is missing required Confluence evidence is not
+ready for maintainer review. Maintainers may label it as needing evidence. If
+it receives no qualifying contributor update within seven days of that notice,
+maintainers may close it. A closed pull request can be reopened when the
+required testing and evidence are ready.
 
 A qualifying update is a contributor-authored commit or pull request body edit
 that addresses the missing requirements. Bot activity, check reruns, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,8 @@ Before opening a pull request, you must:
    change can affect the shipped app.
 4. Record the scenarios and results, and capture appropriate screenshots or a
    recording from Confluence.
-5. Complete the pull request template without placeholders.
+5. Add the Confluence evidence, or explain why the documented exemption applies,
+   in the pull request.
 
 Do not open a draft pull request to bypass these requirements. If a maintainer
 has explicitly requested an early draft for collaboration, explain that in the
@@ -65,24 +66,10 @@ working-tree difference during Forge testing is the contributor-owned `app.id`
 substitution described in that guide; all other tested source must come from
 the recorded commit.
 
-## Automated checks
-
-From `custom-ui`, install the locked dependencies and run:
-
-```bash
-yarn install --frozen-lockfile
-yarn lint
-yarn test --coverage
-yarn build
-```
-
-For changes that affect the Forge app or manifest, also run from `app`:
-
-```bash
-forge lint
-```
-
-Passing these checks is necessary, but it does not replace testing the app in
+Run the relevant local checks in
+[Testing a fork in Confluence](docs/testing-in-confluence.md). GitHub reports CI
+results on the pull request, so contributors do not need to copy those results
+into its description. Passing CI does not replace testing the app in
 Confluence.
 
 ## Test evidence
@@ -90,8 +77,7 @@ Confluence.
 For changes that require real-Confluence testing, the pull request must include:
 
 - the full 40-character commit SHA whose source was tested;
-- the browser and Forge environment used;
-- a short scenario, expected result, and actual result table;
+- the browser used and a short description of what was tested and observed;
 - at least one screenshot from a real Confluence page showing the tested
   behavior, including before and after images for visual changes where
   relevant; and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,146 @@
-# Contributing to mermaid-diagrams-viewer
+# Contributing to Mermaid Diagrams Viewer
 
-Thank you for considering a contribution to `mermaid-diagrams-viewer`! Pull requests, issues and comments are welcome. For pull requests, please:
+Thank you for considering a contribution to Mermaid Diagrams Viewer. Issues,
+discussions, and pull requests are welcome.
 
-* Add tests for new features and bug fixes
-* Follow the existing style
-* Separate unrelated changes into multiple pull requests
+This is a Forge app that runs inside Confluence Cloud. Unit tests and a local
+browser preview cannot reproduce all of the product APIs, iframe behavior,
+sanitization, themes, editor states, and permissions that the released app
+depends on. Changes that can affect the shipped app must therefore be tested in
+a real Confluence Cloud site before a pull request is opened.
 
-See the existing issues for things to start contributing.
+## Before you start
 
-For bigger changes, please make sure you start a discussion first by creating an issue and explaining the intended change.
+- For a substantial feature, new Forge module or scope, storage change, or
+  architectural change, open an issue and agree on the approach with a
+  maintainer first.
+- Keep unrelated changes in separate pull requests.
+- Follow the existing code and file structure.
+- Use an issue or discussion if you need help setting up Forge or Confluence.
+  Do not open a pull request merely to ask a maintainer to complete the
+  integration testing.
 
-Atlassian requires contributors to sign a Contributor License Agreement, known as a CLA. This serves as a record stating that the contributor is entitled to contribute the code/documentation/translation to the project and is willing to have it used in distributions and derivative works (or is willing to transfer ownership).
+## Definition of done
 
-Prior to accepting your contributions we ask that you please follow the appropriate link below to digitally sign the CLA. The Corporate CLA is for those who are contributing as a member of an organization and the individual CLA is for those contributing as an individual.
+Before opening a pull request, you must:
 
-* [CLA for corporate contributors](https://opensource.atlassian.com/corporate)
-* [CLA for individuals](https://opensource.atlassian.com/individual)
+1. Understand the change and review the entire diff, including any
+   AI-generated or AI-modified code.
+2. Add or update automated tests for changed behavior and run the relevant
+   local checks.
+3. Test the source at the final commit in a real Confluence Cloud site when the
+   change can affect the shipped app.
+4. Record the scenarios and results, and capture appropriate screenshots or a
+   recording from Confluence.
+5. Complete the pull request template without placeholders.
+
+Do not open a draft pull request to bypass these requirements. If a maintainer
+has explicitly requested an early draft for collaboration, explain that in the
+pull request.
+
+### When real-Confluence testing is required
+
+Real-Confluence testing is required for changes that can affect users,
+including:
+
+- application code or styling;
+- rendering, configuration, interaction, accessibility, or error behavior;
+- calls to Confluence or Forge APIs;
+- the Forge manifest, modules, scopes, resources, runtime, or deployment;
+- runtime dependencies and dependency upgrades that may affect the generated
+  bundle; and
+- build changes that may alter the shipped application.
+
+Documentation and community-metadata changes that cannot affect the shipped
+application are exempt. Test-only, developer-tooling, and CI changes may
+request an exemption when Confluence testing cannot provide meaningful
+evidence. Explain every exemption in the pull request; maintainers have final
+say when its scope is ambiguous.
+
+Follow [Testing a fork in Confluence](docs/testing-in-confluence.md) for the
+complete setup, test, and evidence process.
+
+The recorded tested commit must match the pull request head. The only permitted
+working-tree difference during Forge testing is the contributor-owned `app.id`
+substitution described in that guide; all other tested source must come from
+the recorded commit.
+
+## Automated checks
+
+From `custom-ui`, install the locked dependencies and run:
+
+```bash
+yarn install --frozen-lockfile
+yarn lint
+yarn test --coverage
+yarn build
+```
+
+For changes that affect the Forge app or manifest, also run from `app`:
+
+```bash
+forge lint
+```
+
+Passing these checks is necessary, but it does not replace testing the app in
+Confluence.
+
+## Test evidence
+
+For changes that require real-Confluence testing, the pull request must include:
+
+- the full 40-character commit SHA whose source was tested;
+- the browser and Forge environment used;
+- a short scenario, expected result, and actual result table;
+- at least one screenshot from a real Confluence page showing the tested
+  behavior, including before and after images for visual changes where
+  relevant; and
+- a short recording or animated image when still images cannot demonstrate an
+  interaction.
+
+Capture evidence after testing the source at the final commit. If you push
+another change, retest and update both the tested SHA and evidence. Show enough
+Confluence context to distinguish the product integration from a standalone or
+mocked preview, but use a personal development site and remove private
+information.
+Never include customer data, tokens, or secrets.
+
+## AI-assisted contributions
+
+AI-assisted contributions are welcome, but generated code is not a finished
+contribution. Maintainers have access to the same generation tools; code
+generation alone is not the difficult part this project needs help with.
+
+The valuable contribution is ownership of the result: reproducing the problem,
+understanding the implementation, validating the final commit in Confluence,
+checking regressions, documenting evidence, and keeping the code maintainable.
+The contributor remains responsible for all submitted code and claims,
+regardless of which tools helped produce it. Never claim a test was run or
+provide evidence that was not produced by the submitted change.
+
+## Incomplete pull requests
+
+A pull request that is missing required Confluence evidence is not ready for
+maintainer review. Maintainers may label it as needing evidence and close it
+after seven days without a qualifying contributor update. A closed pull request
+can be reopened when the required testing and evidence are ready.
+
+A qualifying update is a contributor-authored commit or pull request body edit
+that addresses the missing requirements. Bot activity, check reruns, and
+maintainer comments do not reset the inactivity period.
+
+Pull requests waiting on a maintainer, a broken project service, or another
+confirmed external blocker are exempt from this inactivity policy while the
+blocker remains.
+
+## Contributor License Agreement
+
+Atlassian requires contributors to sign a Contributor License Agreement (CLA).
+The CLA records that you are entitled to contribute the code, documentation, or
+other material and are willing to license it for use in this project.
+
+- [Corporate CLA](https://opensource.atlassian.com/corporate)
+- [Individual CLA](https://opensource.atlassian.com/individual)
+
+Use the same email address for the CLA and your commits so the automated check
+can match them.

--- a/README.md
+++ b/README.md
@@ -32,36 +32,71 @@ This is a Forge app. Install it from the [Atlassian Marketplace](https://marketp
 
 ### Development Setup
 
-Clone the repository and install dependencies:
+Fork and clone the repository, then install dependencies using the Node.js
+version in `.nvmrc`:
 
 ```bash
+nvm install
+nvm use
 cd custom-ui
-yarn # install dependencies
+yarn install --frozen-lockfile
 ```
 
 The project has two directories:
 - `custom-ui` - The React UI for rendering diagrams (all JS tooling lives here)
 - `app` - The Forge app manifest and build output
 
-### Running Locally
+### Test a fork in Confluence
+
+The manifest contains the upstream Forge app ID. Before deploying a fork, use
+`forge register` to create a contributor-owned copy:
 
 ```bash
-# Terminal 1: Start the custom UI dev server
+# From the repository root
+cd app
+forge login
+forge register YOUR_GITHUB_USER-mermaid-viewer
+```
+
+`forge register` rewrites `app.id` in `app/manifest.yml`. Never include that
+personal ID in a commit. The full testing guide explains how to temporarily use
+it for the final deployed test while keeping the upstream ID in Git history.
+
+Build, deploy, and perform the first installation before starting a tunnel:
+
+```bash
+# From the repository root
 cd custom-ui
-yarn dev # starts vite dev server on port 5173
+yarn build
 
-# Terminal 2: Start the Forge tunnel
-cd app
-forge tunnel # proxies requests to local dev server
+cd ../app
+forge lint
+forge deploy --environment development
+forge install \
+  --environment development \
+  --site YOUR_SITE.atlassian.net \
+  --product confluence
 ```
 
-Then install the app on your Confluence instance using:
+For the development loop, run Vite and the Forge tunnel in separate terminals:
+
 ```bash
+# Terminal 1
+cd custom-ui
+yarn dev
+
+# Terminal 2
 cd app
-forge install --upgrade
+forge tunnel --environment development
 ```
 
-### Deploying Locally
+Before opening a pull request, stop the tunnel, rebuild and deploy, then test the
+bundle built from the final commit in a real Confluence Cloud site. Follow
+[Testing a fork in Confluence](docs/testing-in-confluence.md) for the complete
+setup, smoke-test matrix, evidence requirements, installation upgrades, and app
+ID cleanup.
+
+### Deploying a local change
 
 ```bash
 # Build the custom UI
@@ -69,10 +104,13 @@ cd custom-ui
 yarn build
 
 # Deploy to your Forge app
-cd app
-forge deploy
-forge install --upgrade
+cd ../app
+forge lint
+forge deploy --environment development
 ```
+
+Run `forge install --upgrade` after the deploy only when Forge modules, scopes,
+permissions, or other installation metadata changed.
 
 ## Tests
 
@@ -94,7 +132,10 @@ yarn test --coverage
 
 ## Contributions
 
-Contributions to Mermaid Diagrams Viewer are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+Contributions are welcome. Changes that can affect the shipped app must be
+tested in a real Confluence Cloud site, with evidence captured from the final
+commit, before a pull request is opened. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for the definition of done.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ cd app
 forge tunnel --environment development
 ```
 
-Before opening a pull request, stop the tunnel, rebuild and deploy, then test the
-bundle built from the final commit in a real Confluence Cloud site. Follow
+Before marking a pull request ready for review, stop the tunnel, rebuild and
+deploy, then test the bundle built from the final commit in a real Confluence
+Cloud site. Follow
 [Testing a fork in Confluence](docs/testing-in-confluence.md) for the complete
 setup, smoke-test matrix, evidence requirements, installation upgrades, and app
 ID cleanup.
@@ -134,7 +135,7 @@ yarn test --coverage
 
 Contributions are welcome. Changes that can affect the shipped app must be
 tested in a real Confluence Cloud site, with evidence captured from the final
-commit, before a pull request is opened. See
+commit, before a pull request is marked ready for review. See
 [CONTRIBUTING.md](CONTRIBUTING.md) for the definition of done.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -133,10 +133,7 @@ yarn test --coverage
 
 ## Contributions
 
-Contributions are welcome. Changes that can affect the shipped app must be
-tested in a real Confluence Cloud site, with evidence captured from the final
-commit, before a pull request is marked ready for review. See
-[CONTRIBUTING.md](CONTRIBUTING.md) for the definition of done.
+Contributions to Mermaid Diagrams Viewer are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ## License
 

--- a/docs/testing-in-confluence.md
+++ b/docs/testing-in-confluence.md
@@ -1,9 +1,9 @@
 # Testing a fork in Confluence
 
 Changes that can affect the shipped app must be tested in a real Confluence
-Cloud site before a pull request is opened. This guide creates a
-contributor-owned copy of the Forge app, installs it on a development site, and
-tests both the tunnelled source and the final deployed build.
+Cloud site before a pull request is marked ready for review. This guide creates
+a contributor-owned copy of the Forge app, installs it on a development site,
+and tests both the tunnelled source and the final deployed build.
 
 ## Prerequisites
 
@@ -242,6 +242,8 @@ recorded earlier; do not run `forge register` again merely to reconnect it.
 - Forge runs against Atlassian Cloud. If you do not administer a suitable site,
   create the free development site linked in the prerequisites rather than
   trying to test the app in a local Confluence container.
-- If you cannot complete real-Confluence testing, open an issue or discussion
-  describing the blocker. Do not open a pull request without the required
-  evidence.
+- If you cannot complete real-Confluence testing, do not mark the pull request
+  ready for review. Open an issue or discussion describing the blocker. If a
+  specific technical or UX decision must be resolved before work can reasonably
+  continue, state the exact question in an issue and link it from an alignment
+  draft. Maintainer feedback on the draft is limited to that question.

--- a/docs/testing-in-confluence.md
+++ b/docs/testing-in-confluence.md
@@ -1,0 +1,247 @@
+# Testing a fork in Confluence
+
+Changes that can affect the shipped app must be tested in a real Confluence
+Cloud site before a pull request is opened. This guide creates a
+contributor-owned copy of the Forge app, installs it on a development site, and
+tests both the tunnelled source and the final deployed build.
+
+## Prerequisites
+
+You need:
+
+- an Atlassian account;
+- a personal [free Atlassian cloud development site](https://go.atlassian.com/cloud-dev)
+  with Confluence;
+- the Node.js version in [`.nvmrc`](../.nvmrc);
+- Yarn 1; and
+- the [Forge CLI](https://developer.atlassian.com/platform/forge/getting-started/#install-the-forge-cli).
+
+Use a personal development site with disposable test content. Do not install a
+contributor build on a customer site or use customer data in testing or
+screenshots.
+
+## 1. Install the tooling and dependencies
+
+From the repository root:
+
+```bash
+nvm install
+nvm use
+npm install --global @forge/cli
+forge login
+forge whoami
+
+cd custom-ui
+yarn install --frozen-lockfile
+```
+
+Follow the Forge login prompt using the account that owns your development
+site.
+
+## 2. Register your own copy of the app
+
+The repository manifest contains the upstream app ID. Do not deploy or install
+using that registration. Register the copied source tree as an app owned by
+your account:
+
+```bash
+cd ../app
+forge register YOUR_GITHUB_USER-mermaid-viewer
+```
+
+Choose a unique name of at most 50 characters. `forge register` creates a new
+Forge app and rewrites `app.id` in `app/manifest.yml`.
+
+Important:
+
+- Never commit your contributor-owned app ID.
+- Record the original upstream ID and the new contributor-owned ID outside the
+  repository. Reuse the contributor-owned ID when returning to this worktree.
+- Do not run `forge register` repeatedly for the same working tree. Each run
+  creates another registration and disconnects the tree from environments,
+  variables, secrets, and storage belonging to its previous app ID.
+- Keep the generated ID while testing, then restore only `app.id` to the
+  upstream value before committing. If your contribution intentionally changes
+  other manifest fields, take care not to discard those changes.
+
+See the [Forge register reference](https://developer.atlassian.com/platform/forge/cli-reference/register/)
+for the command's ownership and environment behavior.
+
+## 3. Build, deploy, and install it
+
+Forge needs the built Custom UI resource before it can deploy the app:
+
+```bash
+cd ../custom-ui
+yarn build
+
+cd ../app
+forge lint
+forge deploy --environment development
+forge install \
+  --environment development \
+  --site YOUR_SITE.atlassian.net \
+  --product confluence
+```
+
+Use `forge install` without `--upgrade` for the first installation. On later
+runs, deploy the app again. If you changed installation metadata such as Forge
+modules, scopes, or permissions, upgrade the existing installation:
+
+```bash
+forge install \
+  --upgrade \
+  --environment development \
+  --site YOUR_SITE.atlassian.net \
+  --product confluence
+```
+
+## 4. Run the development tunnel
+
+The app manifest maps its Custom UI resource to Vite on port 5173. Start both
+processes and leave them running while you exercise the app.
+
+Terminal 1:
+
+```bash
+cd custom-ui
+yarn dev
+```
+
+Terminal 2:
+
+```bash
+cd app
+forge tunnel --environment development
+```
+
+Open the development site in Chrome or Firefox on the same machine, browser
+session, and account that started the tunnel. The app must already be deployed
+and installed in the development environment. The tunnel only redirects
+requests made by your user.
+
+A tunnel is a fast development loop, not final release evidence. It proxies the
+Custom UI dev server and does not prove that the generated bundle and deployed
+app work. See [Forge tunnelling](https://developer.atlassian.com/platform/forge/tunneling/)
+for current browser, network, and manifest limitations.
+
+## 5. Exercise the relevant Confluence behavior
+
+At minimum, test the regression or feature described by the change and confirm
+that a valid diagram still renders on a published page after a reload. Select
+additional scenarios based on the integration boundaries touched by the diff.
+
+| Area changed | Scenarios to exercise |
+| --- | --- |
+| Rendering or layout | Small and large diagrams, reload, relevant viewport sizes, light and dark themes |
+| Editor or configuration | Create and edit a page, select a code block, save and cancel configuration, publish and reload |
+| Code-block mapping | Multiple Mermaid and non-Mermaid blocks, automatic mapping, explicit selection, reordered blocks |
+| Interaction | Open the full-screen diagram and exercise the affected zoom, pan, or other controls |
+| Errors | Invalid Mermaid input and the specific API or rendering failure changed by the pull request |
+| Content lookup | Published and draft pages; blog-post fallback when that path is affected |
+| Manifest or permissions | Fresh installation or upgrade, changed module behavior, and every newly requested permission |
+
+Record the scenario, expected result, and observed result as you test. Fixes must
+demonstrate the original failure and the corrected behavior where practical.
+
+## 6. Prepare the final commit
+
+The Git commit must contain the upstream app ID, while Forge testing must use
+your contributor-owned ID. Before the final test pass:
+
+1. Record your contributor-owned ID outside the repository.
+2. Restore only `app.id` to the upstream value.
+3. Stage and commit all intended changes. Confirm that the commit does not
+   contain your contributor-owned ID.
+4. Temporarily put your contributor-owned ID back into the working-tree
+   manifest without staging it.
+5. Run `git diff -- app/manifest.yml` and confirm the only uncommitted manifest
+   difference is `app.id`.
+
+The local app-ID substitution selects your Forge registration; it must be the
+only difference between the committed source and the source used for the final
+test.
+
+## 7. Test the final deployed build
+
+After tunnel testing is complete, stop Vite and `forge tunnel`. Run the complete
+local checks and deploy the production bundle:
+
+```bash
+cd custom-ui
+yarn lint
+yarn test --coverage
+yarn build
+
+cd ../app
+forge lint
+forge deploy --environment development
+```
+
+Run `forge install --upgrade` again only when installation metadata changed.
+Perform a full browser reload of Confluence without the tunnel and repeat the
+primary regression or feature scenario plus the published-page smoke test.
+Capture pull request evidence from this final deployed build.
+
+## 8. Capture evidence for the pull request
+
+Record the full SHA of the commit you just tested:
+
+```bash
+git rev-parse HEAD
+```
+
+The pull request must identify that exact 40-character SHA. The local `app.id`
+substitution is the only permitted difference from its source. Include:
+
+- the Forge environment and browser;
+- the scenarios, expected results, and actual results;
+- screenshots with enough Confluence UI visible to establish the real product
+  context;
+- before and after images for visual fixes; and
+- a recording or animated image for interactions that still images cannot
+  demonstrate.
+
+If testing results in another code change, restore the upstream app ID before
+committing, make the change, then repeat the preparation and test process with
+the new head. Evidence for an older commit does not validate the new head
+commit.
+
+## 9. Restore the upstream app ID
+
+After capturing evidence, restore the committed manifest and inspect the
+working tree:
+
+```bash
+git restore app/manifest.yml
+git diff --check
+git status --short
+```
+
+Because the intended manifest changes were committed in step 6, restoring the
+file now preserves them and removes the temporary contributor-owned ID. The
+working tree should be clean, and your contributor-owned Forge ID must not
+appear in the pull request.
+
+Do not run another Forge command while the worktree contains the upstream app
+ID. For later testing, temporarily restore the contributor-owned ID that you
+recorded earlier; do not run `forge register` again merely to reconnect it.
+
+## Troubleshooting
+
+- If a copied app cannot deploy or install, use `forge register`, not
+  `forge create`.
+- If the tunnel receives no requests, confirm the app is deployed and installed
+  in the same development environment and that you are using the same browser
+  account. VPNs, proxies, and firewalls can also block the Cloudflare tunnel.
+- If Forge reports an authentication or permission error, run `forge login` and
+  `forge whoami` again and resolve the account or token problem. Do not treat a
+  tooling failure as permission to skip Confluence testing.
+- If you edit `manifest.yml`, deploy again. Changes to modules, scopes, or
+  permissions may also require `forge install --upgrade`.
+- Forge runs against Atlassian Cloud. If you do not administer a suitable site,
+  create the free development site linked in the prerequisites rather than
+  trying to test the app in a local Confluence container.
+- If you cannot complete real-Confluence testing, open an issue or discussion
+  describing the blocker. Do not open a pull request without the required
+  evidence.


### PR DESCRIPTION
## Summary

- require real-Confluence testing and screenshots before app-affecting pull requests are marked ready for review
- allow draft pull requests for high-level alignment, with feedback limited to a specific technical or UX question raised in a linked issue
- explain how contributors can register and test their own copy safely
- add concise instructions for AI agents and Copilot review
- add a pull request template that asks only for information GitHub cannot provide

The evidence validator and seven-day closure workflow will follow separately.

## Confluence test

Not applicable. This PR changes documentation and GitHub community metadata only; it does not change the app, Forge manifest, dependencies, build, or deployment.
