### PR TITLE
fix(custom-ui): only reserve min-height while the diagram is loading

### DIFF
--- a/custom-ui/src/__tests__/app.test.tsx
+++ b/custom-ui/src/__tests__/app.test.tsx
@@ -131,14 +131,18 @@ describe('App Component', () => {
     const appError = new AppError('Test error', 'TEST_ERROR');
     mockGetCodeFromCorrespondingBlock.mockRejectedValue(appError);
 
+    let renderResult!: ReturnType<typeof render>;
     act(() => {
-      render(<App colorMode="light" />);
+      renderResult = render(<App colorMode="light" />);
     });
 
     await waitFor(() => {
       expect(screen.getByText(/Error while loading diagram/)).toBeDefined();
       expect(screen.getByText(/Test error/)).toBeDefined();
     });
+
+    const container = renderResult.container.firstChild as HTMLElement;
+    expect(container.style.minHeight).toBe('');
   });
 
   it('handles unknown error from getCodeFromCorrespondingBlock', async () => {
@@ -202,5 +206,42 @@ describe('App Component', () => {
         undefined,
       );
     });
+  });
+
+  it('reserves a 150px min-height while loading', async () => {
+    let resolveCode: (value: string) => void = () => {};
+    mockGetCodeFromCorrespondingBlock.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveCode = resolve;
+      }),
+    );
+
+    let renderResult!: ReturnType<typeof render>;
+    act(() => {
+      renderResult = render(<App colorMode="light" />);
+    });
+
+    const container = renderResult.container.firstChild as HTMLElement;
+    expect(container.style.minHeight).toBe('150px');
+
+    // Settle the pending load so the effect resolves without act() warnings.
+    await act(async () => {
+      resolveCode('graph TD\n  A --> B');
+      await Promise.resolve();
+    });
+  });
+
+  it('drops the min-height once loading completes', async () => {
+    let renderResult!: ReturnType<typeof render>;
+    act(() => {
+      renderResult = render(<App colorMode="light" />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('diagram')).toBeDefined();
+    });
+
+    const container = renderResult.container.firstChild as HTMLElement;
+    expect(container.style.minHeight).toBe('');
   });
 });

--- a/custom-ui/src/app.tsx
+++ b/custom-ui/src/app.tsx
@@ -89,15 +89,20 @@ function App({ colorMode }: { colorMode: 'light' | 'dark' }) {
     setError(error);
   };
 
+  const isLoading = code === undefined && error === undefined;
+
   return (
     <div
       style={{
-        minHeight: '150px',
+        // Reserve vertical space only while the loading spinner is shown. Once
+        // loading finishes, let the container hug its content so a short
+        // diagram does not leave empty vertical space below it.
+        minHeight: isLoading ? '150px' : undefined,
         backgroundColor: token('elevation.surface'),
         borderRadius: '3px',
       }}
     >
-      {code === undefined && error === undefined ? <Loading /> : null}
+      {isLoading ? <Loading /> : null}
       {code !== undefined ? (
         <Diagram code={code} colorMode={colorMode} onError={onError} />
       ) : null}


### PR DESCRIPTION
## Summary

Keep the macro container's 150px minimum height only while the existing loading spinner is shown. After loading settles, the container uses its natural content height so short Mermaid diagrams no longer leave empty vertical space.

This reapplies the focused change from #136 on the current `main`, as requested by the maintainer. Regression tests cover the loading, settled, and error states.

## Confluence test

Test status: `TESTED`

Tested commit: `b4a948df855cdfc7d3e87cb74e3874141425cdda`

Browser: `Google Chrome 150.0.7871.125 on macOS 26.3.1`

What I tested:

- Built and deployed the final commit to a contributor-owned Forge `development` environment, then tested a published page in a personal Confluence Cloud site with the tunnel stopped. The only working-tree difference from the tested commit was the contributor-owned `app.id` substitution.
- Performed a full page reload with a small `flowchart LR` diagram. On `main` (`4aeb9eece62c1030fbe6edd1daacf3fbd5a142f4`), the rendered App and outer iframe remained 150px high. On the final commit, both settled at 72px; a following content marker moved from y=530px to y=452px while its normal 12px gap remained unchanged.
- Observed the final commit's loading-to-render transition: the App and iframe held 150px while loading, then resized to 72px after the diagram settled.
- Checked the small diagram at the default 1473x1030 viewport and at 900x800. At 900x800 the iframe was 756x72 and the page had no horizontal overflow (`scrollWidth === clientWidth === 900`).
- Checked a larger flowchart in light and dark themes. It rendered all nodes and labels at 760x699 with no horizontal overflow, then the page was restored to the small diagram and light theme.

Evidence:

The `NEXT CONTENT MARKER` paragraph makes the otherwise transparent outer iframe height visible. The screenshots are cropped to omit private account details while retaining the Confluence code block, Forge macro, and following page content.

Before — `main` at `4aeb9eece62c1030fbe6edd1daacf3fbd5a142f4` (Forge development 2.5.0, 150px):

![Before: the following content marker is separated by the 150px macro height](https://raw.githubusercontent.com/nahyeongjin1/mermaid-diagrams-viewer/94f6569c8b896597aca96276997f15b5463038de/pr-153-before.png)

After — final commit `b4a948df855cdfc7d3e87cb74e3874141425cdda` (Forge development 2.6.0, 72px):

![After: the following content marker moves up after the macro uses its natural height](https://raw.githubusercontent.com/nahyeongjin1/mermaid-diagrams-viewer/94f6569c8b896597aca96276997f15b5463038de/pr-153-after.png)

Why this is not applicable:

N/A — this visual app change was tested in real Confluence.
